### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "hold",
     "event"
   ],
-  "dependencies": {
-    "react": "^0.14.7",
-    "react-dom": "^0.14.7"
+  "peerDependencies": {
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixed issue causing copy of react to launch ontop of running copy.

Run in devtools w/ react developers tools:

__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers.forEach(r => console.log(`${r.rendererPackageName}: ${r.version}`))

VM2846:1 react-dom: 16.13.1
VM2846:1 undefined: undefined

Causes two copies to load, which throws errors in react developer tools for example.
Tested with and without this package loaded.

All the best!

Additional info: https://github.com/facebook/react-devtools/issues/813